### PR TITLE
fix: audio not stopping when app on background

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -41,6 +41,7 @@ class App extends StatelessWidget {
               return audioController
                 ..attachLifecycleNotifier(lifecycleNotifier);
             },
+            lazy: false,
           ),
           RepositoryProvider<SettingsController>.value(
             value: settingsController,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

The bug:
When launching the app, enabling sound and closing, the sound was kept on.

The solution:
The app lifecycle listener was being registered only when the audio controller was accessed by the provider (a.k.a. when pressing "play"). This PR avoids the lazy loading of the provider, making it register the lifecycle listener when launching the app.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
