### PR TITLE
fix: tap while respawning made dash invincible forever

### DIFF
--- a/lib/game/behaviors/player_controller_behavior.dart
+++ b/lib/game/behaviors/player_controller_behavior.dart
@@ -27,6 +27,7 @@ class PlayerControllerBehavior extends Behavior<Player> {
   void _handleInput() {
     if (parent.isDead ||
         parent.isPlayerTeleporting ||
+        parent.isPlayerRespawning ||
         parent.isGoingToGameOver) {
       return;
     }

--- a/lib/game/entities/player.dart
+++ b/lib/game/entities/player.dart
@@ -30,6 +30,7 @@ class Player extends JumperCharacter<DashRunGame> {
   List<ItemType> powerUps = [];
   bool isPlayerInvincible = false;
   bool isPlayerTeleporting = false;
+  bool isPlayerRespawning = false;
 
   bool get doubleJumpEnabled => powerUps.contains(ItemType.goldenFeather);
 
@@ -246,9 +247,10 @@ class Player extends JumperCharacter<DashRunGame> {
       return (a - position).length2 < (b - position).length2 ? a : b;
     });
 
+    isPlayerRespawning = true;
     isPlayerInvincible = true;
     walking = false;
-    final behavior = stateBehavior..fadeOut();
+    stateBehavior.fadeOut();
     add(
       MoveToEffect(
         closestRespawn.clone(),
@@ -259,8 +261,9 @@ class Player extends JumperCharacter<DashRunGame> {
         ),
       ),
     );
-    behavior.fadeIn(
+    stateBehavior.fadeIn(
       onComplete: () {
+        isPlayerRespawning = false;
         isPlayerInvincible = false;
         walking = true;
       },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

If "space" was pressed (or tapped in mobile) while dash was respawning, made the respawn movement stop, and made dash invincible forever. This PR fixes that by disallowing input while respawning.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
