### PR TITLE
fix: Wrap BottomBar contents in SafeArea

### DIFF
--- a/lib/game_intro/widgets/bottom_bar.dart
+++ b/lib/game_intro/widgets/bottom_bar.dart
@@ -12,39 +12,41 @@ class BottomBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 32),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          const AudioButton(),
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                l10n.superDash,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 4),
-              RichText(
-                text: TextSpan(
-                  text: l10n.howItsMade,
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const AudioButton(),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  l10n.superDash,
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: Colors.white,
-                    fontWeight: FontWeight.w400,
-                    decoration: TextDecoration.underline,
+                    fontWeight: FontWeight.bold,
                   ),
-                  recognizer: TapGestureRecognizer()
-                    ..onTap = () => launchUrlString(Urls.howWeBuilt),
                 ),
-              ),
-            ],
-          ),
-          const InfoButton(),
-        ],
+                const SizedBox(height: 4),
+                RichText(
+                  text: TextSpan(
+                    text: l10n.howItsMade,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w400,
+                      decoration: TextDecoration.underline,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () => launchUrlString(Urls.howWeBuilt),
+                  ),
+                ),
+              ],
+            ),
+            const InfoButton(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Wraps the contents of the BottomBar in a SafeArea. This adds a bit of bottom padding to keep BottomBar contents outside of iOS safe area insets on iPhone X and later devices.

Previously, the "How it's made" link was inside the iOS safe areas, making it difficult to tap on iPhones.

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
