### PR TITLE
feat: collect wings to increase the chance to get higher score

### DIFF
--- a/lib/game/bloc/game_bloc.dart
+++ b/lib/game/bloc/game_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 
@@ -10,6 +12,8 @@ class GameBloc extends Bloc<GameEvent, GameState> {
     on<GameScoreDecreased>(_onGameScoreDecreased);
     on<GameOver>(_onGameOver);
     on<GameSectionCompleted>(_onGameSectionCompleted);
+    on<GameWingsIncreased>(_onGameWingsIncreased);
+    on<GameWingsDecreased>(_onGameWingsDecreased);
   }
 
   void _onGameScoreIncreased(
@@ -30,6 +34,28 @@ class GameBloc extends Bloc<GameEvent, GameState> {
     emit(
       state.copyWith(
         score: state.score - event.by,
+      ),
+    );
+  }
+
+  void _onGameWingsIncreased(
+    GameWingsIncreased event,
+    Emitter<GameState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        wingsQty: min(state.wingsQty + event.by, GameState.maxWingsQty),
+      ),
+    );
+  }
+
+  void _onGameWingsDecreased(
+    GameWingsDecreased event,
+    Emitter<GameState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        wingsQty: state.wingsQty - event.by,
       ),
     );
   }

--- a/lib/game/bloc/game_event.dart
+++ b/lib/game/bloc/game_event.dart
@@ -25,6 +25,24 @@ final class GameScoreDecreased extends GameEvent {
   List<Object> get props => [by];
 }
 
+final class GameWingsIncreased extends GameEvent {
+  const GameWingsIncreased({this.by = 1});
+
+  final int by;
+
+  @override
+  List<Object> get props => [by];
+}
+
+final class GameWingsDecreased extends GameEvent {
+  const GameWingsDecreased({this.by = 1});
+
+  final int by;
+
+  @override
+  List<Object> get props => [by];
+}
+
 final class GameOver extends GameEvent {
   const GameOver();
 }

--- a/lib/game/bloc/game_state.dart
+++ b/lib/game/bloc/game_state.dart
@@ -3,31 +3,38 @@ part of 'game_bloc.dart';
 class GameState extends Equatable {
   const GameState({
     required this.score,
+    required this.wingsQty,
     required this.currentLevel,
     required this.currentSection,
   });
 
   const GameState.initial()
       : score = 0,
+        wingsQty = 0,
         currentLevel = 1,
         currentSection = 0;
 
   final int score;
+  final int wingsQty;
   final int currentLevel;
   final int currentSection;
 
+  static const maxWingsQty = 5;
+
   GameState copyWith({
     int? score,
+    int? wingsQty,
     int? currentLevel,
     int? currentSection,
   }) {
     return GameState(
       score: score ?? this.score,
+      wingsQty: wingsQty ?? this.wingsQty,
       currentLevel: currentLevel ?? this.currentLevel,
       currentSection: currentSection ?? this.currentSection,
     );
   }
 
   @override
-  List<Object?> get props => [score, currentLevel, currentSection];
+  List<Object?> get props => [score, wingsQty, currentLevel, currentSection];
 }

--- a/lib/game/entities/player.dart
+++ b/lib/game/entities/player.dart
@@ -27,7 +27,6 @@ class Player extends JumperCharacter<SuperDashGame> {
   late final PlayerStateBehavior stateBehavior =
       findBehavior<PlayerStateBehavior>();
 
-  bool hasGoldenFeather = false;
   bool isPlayerInvincible = false;
   bool isPlayerTeleporting = false;
   bool isPlayerRespawning = false;
@@ -41,6 +40,8 @@ class Player extends JumperCharacter<SuperDashGame> {
 
   @override
   int get priority => 1;
+
+  bool get hasGoldenFeather => gameRef.state.wingsQty > 0;
 
   void jumpEffects() {
     final jumpSound = hasGoldenFeather ? Sfx.phoenixJump : Sfx.jump;
@@ -125,7 +126,9 @@ class Player extends JumperCharacter<SuperDashGame> {
   }
 
   void addPowerUp() {
-    hasGoldenFeather = true;
+    gameRef.gameBloc.add(
+      const GameWingsIncreased(),
+    );
 
     if (stateBehavior.state == DashState.idle) {
       stateBehavior.state = DashState.phoenixIdle;
@@ -172,7 +175,10 @@ class Player extends JumperCharacter<SuperDashGame> {
       }
 
       // If player has a golden feather, use it to avoid death.
-      hasGoldenFeather = false;
+      gameRef.gameBloc.add(
+        const GameWingsDecreased(),
+      );
+
       return respawn();
     }
 
@@ -213,7 +219,10 @@ class Player extends JumperCharacter<SuperDashGame> {
         }
 
         // If player has a golden feather, use it to avoid death.
-        hasGoldenFeather = false;
+        gameRef.gameBloc.add(
+          const GameWingsDecreased(),
+        );
+
         return respawn();
       }
     }

--- a/lib/game/widgets/score_label.dart
+++ b/lib/game/widgets/score_label.dart
@@ -12,8 +12,8 @@ class ScoreLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     final textTheme = Theme.of(context).textTheme;
-    final score = context.select(
-      (GameBloc bloc) => bloc.state.score,
+    final state = context.select(
+      (GameBloc bloc) => (score: bloc.state.score, wings: bloc.state.wingsQty),
     );
 
     return SafeArea(
@@ -37,7 +37,18 @@ class ScoreLabel extends StatelessWidget {
               ),
               const SizedBox(width: 10),
               Text(
-                l10n.gameScoreLabel(score),
+                l10n.gameScoreLabel(state.score),
+                style: textTheme.titleLarge?.copyWith(
+                  color: const Color(0xFF4D5B92),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Assets.images.powerfulWingsInstruction.image(
+                width: 40,
+                height: 40,
+              ),
+              Text(
+                l10n.wingsQtyLabel(state.wings),
                 style: textTheme.titleLarge?.copyWith(
                   color: const Color(0xFF4D5B92),
                 ),

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -185,6 +185,15 @@
             }
         }
     },
+    "wingsQtyLabel": "{points}x Wings",
+    "@wingsQtyLabel": {
+        "description": "Text shown on the game wings label",
+        "placeholders": {
+            "points": {
+                "type": "int"
+            }
+        }
+    },
     "leaderboardPageLeaderboardHeadline": "Leaderboard",
     "@leaderboardPageLeaderboardHeadline": {
         "description": "Text shown in the leaderboard page headline"

--- a/test/game/bloc/game_bloc_test.dart
+++ b/test/game/bloc/game_bloc_test.dart
@@ -13,6 +13,7 @@ void main() {
         score: 100,
         currentLevel: 2,
         currentSection: 2,
+        wingsQty: 2,
       ),
       act: (bloc) => bloc.add(GameOver()),
       expect: () => const [GameState.initial()],
@@ -34,6 +35,35 @@ void main() {
       seed: () => const GameState.initial().copyWith(score: 100),
       act: (bloc) => bloc.add(GameScoreDecreased(by: 2)),
       expect: () => [const GameState.initial().copyWith(score: 98)],
+    );
+
+    blocTest<GameBloc, GameState>(
+      'emits GameState with wings increased correctly '
+      'when dash collect a wing',
+      build: GameBloc.new,
+      seed: () => const GameState.initial().copyWith(wingsQty: 1),
+      act: (bloc) => bloc.add(GameWingsIncreased()),
+      expect: () => [const GameState.initial().copyWith(wingsQty: 2)],
+    );
+
+    blocTest<GameBloc, GameState>(
+      'emits GameState with wings decreased correctly '
+      'when dash lost a wing',
+      build: GameBloc.new,
+      seed: () => const GameState.initial().copyWith(wingsQty: 1),
+      act: (bloc) => bloc.add(GameWingsDecreased()),
+      expect: () => [const GameState.initial().copyWith(wingsQty: 0)],
+    );
+
+    blocTest<GameBloc, GameState>(
+      'not emits GameState when dash collect a '
+          'new wing and exceed the max wings qty',
+      build: GameBloc.new,
+      seed: () => const GameState.initial().copyWith(
+        wingsQty: GameState.maxWingsQty,
+      ),
+      act: (bloc) => bloc.add(GameWingsIncreased()),
+      expect: () => <GameState>[],
     );
   });
 }

--- a/test/game/bloc/game_state_test.dart
+++ b/test/game/bloc/game_state_test.dart
@@ -21,7 +21,7 @@ void main() {
     test('returns object with updated score when score is passed', () {
       expect(
         GameState.initial().copyWith(score: 100),
-        GameState(score: 100, currentLevel: 1, currentSection: 0),
+        GameState(score: 100, currentLevel: 1, currentSection: 0, wingsQty: 0),
       );
     });
 
@@ -30,7 +30,7 @@ void main() {
       () {
         expect(
           GameState.initial().copyWith(currentLevel: 2),
-          GameState(score: 0, currentLevel: 2, currentSection: 0),
+          GameState(score: 0, currentLevel: 2, currentSection: 0, wingsQty: 0),
         );
       },
     );
@@ -38,7 +38,14 @@ void main() {
     test('returns object with updated currentSection when score is passed', () {
       expect(
         GameState.initial().copyWith(currentSection: 3),
-        GameState(score: 0, currentLevel: 1, currentSection: 3),
+        GameState(score: 0, currentLevel: 1, currentSection: 3, wingsQty: 0),
+      );
+    });
+
+    test('returns object with updated wings when wings is passed', () {
+      expect(
+        GameState.initial().copyWith(wingsQty: 2),
+        GameState(score: 0, currentLevel: 1, currentSection: 0, wingsQty: 2),
       );
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I don't know if it's just me, but (especially on a smartphone) the game is not easy ;). In addition, there is currently no advantage if you have collected a new super wing with currently active one. That's why I thought it would make sense if you could collect the wings to increase your chances of getting a high score. You could see the wing as a kind of life indicator which increases the time until the "last" life before game over. The maximum number of collected wings is currently limited to 5. 

<img width="331" alt="Bildschirmfoto 2023-12-16 um 12 56 12" src="https://github.com/flutter/super_dash/assets/22661573/3aa0ef38-9c9e-429e-804f-25291449cf33">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
